### PR TITLE
fix: change template owner to skills in copy exercise button

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In this exercise, you will:
 
 Simply copy the exercise to your account, then give your favorite Octocat (Mona) **about 20 seconds** to prepare the first lesson, then **refresh the page**.
 
-[![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/new?template_owner=skills-dev&template_name=copilot-code-review&owner=%40me&name=skills-copilot-code-review&description=Exercise:+GitHub+Copilot+Code+Review&visibility=public)
+[![](https://img.shields.io/badge/Copy%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/new?template_owner=skills&template_name=copilot-code-review&owner=%40me&name=skills-copilot-code-review&description=Exercise:+GitHub+Copilot+Code+Review&visibility=public)
 
 <details>
 <summary>Having trouble? 🤷</summary><br/>


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

Users were not able to start the exercise as the start exercise button still leads to the `skills-dev` org


### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/copilot-code-review/issues/9

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
