### PR TITLE
Update references from skills-dev to skills organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Leverage GitHub Copilot code review to promote code quality and catch issues be
 
   - GitHub Copilot subscription (paid plan is required)
   - Familiarity with reviewing code in pull requests
-  - Familiarity with Codespaces, or [Code with Codespaces](https://github.com/skills-dev/code-with-codespaces) Skills exercise
+  - Familiarity with Codespaces, or [Code with Codespaces](https://github.com/skills/code-with-codespaces) Skills exercise
   - Familiarity with GitHub Copilot, or [Getting Started with GitHub](https://github.com/skills/getting-started-with-github-copilot) Skills exercise
 
 - **How long**: This exercise takes less than 1 hour to complete.


### PR DESCRIPTION
## Summary

This PR updates all references from the `skills-dev` organization to the `skills` organization.

## Context

We have merged all repositories from the `skills-dev` organization into the main `skills` organization. This PR updates any links and references that still point to `skills-dev` to ensure they point to the correct organization.

## Changes

- Updated repository references from `skills-dev` to `skills`
- No functional changes, only URL/reference updates