### PR TITLE
Update finish-exercise workflow version to v0.9.3

### DIFF
--- a/.github/workflows/4-step.yml
+++ b/.github/workflows/4-step.yml
@@ -132,7 +132,7 @@ jobs:
   finish_exercise:
     name: Finish Exercise
     needs: [find_exercise, post_review_content]
-    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.7.0
+    uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.9.3
     with:
       issue-url: ${{ needs.find_exercise.outputs.issue-url }}
       exercise-title: "GitHub Copilot Code Review"


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->


Updated the `exercise-toolkit/finish_exercise` workflow to latest version `v0.9.3` which now will stop leading users to repository home for udpates after they completed the exercise. This is done conditionally now based on the `update-readme-with-congratulation` which this repository already set to `false`. This was done because we can't update the README since a ruleset to protect main branch was created as part of the exercise

Based on that setting now in `exercise-toolkit/finish_exercise@v0.9.3` the message will be adjusted to simply congratulate on finishing the exercise without linking back to repository home /README

### Changes
<!-- Describe the changes this pull request introduces. -->


 
This pull request updates the `finish_exercise` workflow in `.github/workflows/4-step.yml` to use a newer version of the `skills/exercise-toolkit` action. This ensures the workflow benefits from the latest features and fixes.

Workflow dependency update:

* Updated the `finish_exercise` job to use `skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.9.3` instead of `v0.7.0` in `.github/workflows/4-step.yml`, ensuring the workflow uses the latest improvements and bug fixes from the toolkit.
<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
